### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,16 +1,16 @@
-Motor		KEYWORD1
-DVR8837		KEYWORD1
+Motor	KEYWORD1
+DVR8837	KEYWORD1
 DualHBridge	KEYWORD1
 
 
-brake		KEYWORD2
-coast		KEYWORD2
-write		KEYWORD2
-read		KEYWORD2
+brake	KEYWORD2
+coast	KEYWORD2
+write	KEYWORD2
+read	KEYWORD2
 isEnabled	KEYWORD2
-mirror		KEYWORD2
-enableCoastMode KEYWORD2
-enable 		KEYWORD2
-disable 	KEYWORD2
+mirror	KEYWORD2
+enableCoastMode	KEYWORD2
+enable	KEYWORD2
+disable	KEYWORD2
 
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords